### PR TITLE
feat: Consists if slider_settings and atts are array and are not empty

### DIFF
--- a/wp-client-logo-carousel.php
+++ b/wp-client-logo-carousel.php
@@ -202,7 +202,7 @@ function wpaft_logo_slider_callback( $atts ) {
 	//echo $slider_settings;
 	
     $order_by='date';//default value
-	if($slider_settings['slide_orderby']!=''){
+	if(is_array($slider_settings) && !empty($slider_settings['slide_orderby'])){
      $order_by = $slider_settings['slide_orderby']; 
 	}
 	$order= 'DESC';
@@ -211,8 +211,8 @@ function wpaft_logo_slider_callback( $atts ) {
 	}
 	
 	$category='default'; // default category
-	$add_id='default';
-	if( isset($atts['category']) and $atts['category'] !=''){
+	// Verify $atts is array and category index is not empty
+	if(is_array($atts) && !empty($atts['category'])){
 		$add_id=$atts['category']; //additional id 
 	}
 	
@@ -239,9 +239,9 @@ function wpaft_logo_slider_callback( $atts ) {
 	/*
  *  Initialize the slider
  */
-
+	<?php $slider_id = $add_id ?? 0; ?>
 		jQuery(document).ready(function($){ 
-			jQuery("#wpaft-logo-slider-<?php echo $add_id;?>").owlCarousel({
+			jQuery("#wpaft-logo-slider-<?php echo $slider_id;?>").owlCarousel({
 				items: 				Number(wpaft.items),
 				slideSpeed: 		Number(wpaft.slide_speed),
 				paginationSpeed: 	Number(wpaft.pagination_speed),


### PR DESCRIPTION
Verify if $slider_settings and $atts are arrays and not empty.
Where the owlCarousel is loaded and in the code below, there is a variable called $add_id, which serves to assemble the sliders.
The change made in line 215 this variable will be null which will end up breaking the pages where the carousel is used.
To do so, create a variable and replace $add_id with the new variable created, so if $add_id returns false or does not exist, this new variable will have a value of 0.